### PR TITLE
Faster bit reading, more stats

### DIFF
--- a/examples/igdpp.cpp
+++ b/examples/igdpp.cpp
@@ -38,6 +38,8 @@ int main(int argc, char *argv[]) {
         std::cout << "Stats for " << filename << std::endl;
         std::cout << "  Variants: " << igd.numVariants() << std::endl;
         std::cout << "  Individuals: " << igd.numIndividuals() << std::endl;
+        std::cout << "  Ploidy: " << igd.getPloidy() << std::endl;
+        std::cout << "  Phased?: " << (igd.isPhased() ? "true" : "false") << std::endl;
         std::cout << "  Source: " << igd.getSource() << std::endl;
         std::cout << "  Genome range: " << igd.getPosition(0)
                                         << "-" << igd.getPosition(igd.numVariants()-1) << std::endl;


### PR DESCRIPTION
* Add ploidy/phasedness to igdpp
* Speed up conversion from bitvectors to sample lists by as much as 2x, by iterating bytes instead of samples. Add a helper for rounding up.