### PR TITLE
IGD format v3, part of release 2 of picovcf

### DIFF
--- a/IGD.FORMAT.md
+++ b/IGD.FORMAT.md
@@ -7,12 +7,13 @@ starts at the 0th byte of the file, and is 128 bytes in size:
 | ---- | ---- | ---- | ---- |
 | 0 | 8 | magic | Magic number that identifies the file as an IGD: 0x3a0c6fd7945a3481 |
 | 8 | 8 | version | The version of the file format. Only incremented on breaking changes |
-| 16 | 8 | ploidy | Ploidy of each individual, >= 1 |
+| 16 | 4 | ploidy | Ploidy of each individual, >= 1 |
+| 20 | 4 | sparseThreshold | Threshold that determines whether a sample list is stored as a bitvector or sparse list. |
 | 24 | 8 | numVariants | The number of total variants in the file |
 | 32 | 8 | numIndividuals | The number of total individuals in the file |
 | 40 | 8 | flags | Bitwise flags; the only one right now is 0x1, which if set means the data is phased |
-| 48 | 8 | filePosVariants | The file position of the first variant data entry - this data does not contain genotypes, just information about variants |
-| 56 | 8 | filePosMissingData | The file position of the missing data map, which is an optionally-loadable part of the file |
+| 48 | 8 | filePosIndex | The file position of the index describing the genomic and file positions of all variants. |
+| 56 | 8 | filePosVariants | The file position of the first variant data entry - this data does not contain genotypes, just information about variants |
 | 64 | 8 | filePosIndividualIds | The file position of the identifiers (labels) for individuals, left at 0 if there are no identifiers |
 | 72 | 56 | reserved | Reserved data for future fields. MUST be set to 0 when an IGD file is created |
 
@@ -22,12 +23,27 @@ Immediately after the header are two variable-sized string fields:
 1. "Source": where the IGD file data came from (often information about data conversion).
 2. "Description": just a general field to hold information about the dataset.
 
-Next is the genotype data:
-* There are `numVariants` consecutive entries.
-* Each entry is an 8-byte genome position, followed by `ploidy*numIndividuals` bits, rounded up to the next byte.
-* Given a variant index (0-based) `i`, we can then find the genotype for that variant by starting at the 0th one and adding `i * (((numIndividuals * ploidy) + 7) / 8)` to it.
+### SizedList Samples
 
-The above are the only required-to-be-consecutive parts of the IGD file. There are three remaining sections that can be anywhere in the file (_after_ the above), and use the header fields to indicate where they are.
+Sparse representation of the samples as a list of indexes. If the list contains value `i`, then the `ith` sample has the alternate allele represented by the particular row.
+
+The layout is:
+  * The 8-byte number of samples (NOT individuals) that are in the list.
+  * An 8-byte index that corresponds to the sample in the list: this value is between `0...((ploidy*numIndividuals)-1)`.
+
+### BitVector Samples
+
+Non-sparse representation of the samples as a bitvector. A `1` indicates the alternate allele, a `0` represents the reference allele. There are `ploidy*numIndividuals` bits, rounded up to the next byte. The end of the row can by found then by `startingPosition + (((numIndividuals * ploidy) + 7) / 8)`. Bit `startingPosition + i` refers to the `ith` sample.
+
+## Sample Rows
+
+Immediately following the header and string fields is the sample row data. This data should be accessed only via the corresponding `IndexEntry`, which describes the layout.
+
+Note that we only support one alternate per variant, which means that converting from a file format like VCF requires "expanding" the variants. A single VCF variant with `N` alternate alleles will become `N` IGD variants.
+
+The above are the only required-to-be-consecutive parts of the IGD file. The remaining sections can be anywhere in the file (_after_ the above), and use the header fields to indicate where they are.
+
+## Common Datatypes
 
 ## Variant Information
 
@@ -45,9 +61,13 @@ Identifiers for each individual are at `filePosIndividualIds` if it is not `0`. 
 
 ## Missing Data
 
-The expectation is that missing data is fairly sparse, so we store it separate from the other genotype data. The missing data is stored as:
-* An 8-byte value indicating how many entries there are.
-* For each entry:
-  * The 8-byte genomic position that is missing the data.
-  * The 8-byte number of samples (NOT individuals) that are missing the data.
-  * An 8-byte index that corresponds to the sample that has missing data: this value is between `0...(ploidy*numIndividuals)`.
+At position identified by `filePosMissingData` in the header. Has less-than-or-equal-to `numVariants` entries, each of which is a `SizedList`. Should be accessed via the `IndexEntry`, as otherwise you don't know which variant each row of data is for (since the `filePosMissingRow` in `IndexEntry` can be `0`, meaning there is none of that variant).
+
+## The Index
+
+At position identified by `filePosIndex` is the file index. There are `numVariants` consecutive `IndexEntry`s following this layout:
+| Byte Offset | Byte Size | Name | Description |
+| ---- | ---- | ---- | ---- |
+| 0 | 1 | flags | Flags describing properties of this variant. Can be 0 (nothing) or a bitwise combination of: `SPARSE=0x1`, `IS_MISSING=0x2` |
+| 1 | 7 | bpPosition | The position on the genome in base pairs for this variant. |
+| 8 | 16 | filePosDataRow | The file position for the sample row. This can be sparse (see `SizedList`) or a bit vector (see `BitVector`), depending on if flag `SPARSE` is set. If `IS_MISSING` flag is set, this represents missing data from this variant. |

--- a/README.md
+++ b/README.md
@@ -43,16 +43,13 @@ DOC_BUILD_DIR=$PWD sphinx-build -c ../doc/ -b html -Dbreathe_projects.picovcf=$P
 `picovcf` also defines an extremely simple binary file format that can be used for fast access to genotype data. Most other genotype data formats are not indexable directly: that is, you cannot jump directly to the 1 millionth variant without first scanning all the previous (almost million) variants. IGD has the following properties:
 * Indexable. You can use math to figure out where the `i`th variant will be in the file.
 * Uncompressed. No need to link in compression libraries.
-* Simple format: all variants are expanded into binary variants. So if a Variant has `N` alternate alleles, then IGD will store that as `N` rows containing `0` (reference allele) or `1` (alternate allele).
-* Reasonably small. It is slightly larger than more complex file formats (like BGEN), but usually within a factor of `3`-`4` in filesize.
+* Simple format: all variants are expanded into binary variants. So if a Variant has `N` alternate alleles, then IGD will store that as `N` rows containing `0` (reference allele) or `1` (alternate allele). Each of these binary variants is stored as either a bitvector (non-sparse) or a list of sample indexes (sparse). A flag in the index indicates which way each variant is stored.
+* Very small. Oftentimes smaller than compressed formats like `.vcf.gz` or `.bgen`. The more low-frequency mutations (such as for really large sample sizes) the smaller the file, assuming you are using the default implementation of dynamically choosing between sparse/non-sparse representation.
 
 For example, the following are from chromosome 22 of a real dataset:
 * `.vcf`: 11GB
 * `.vcf.gz`: 203MB
 * `.bgen`: 256MB
-* `.igd`: 691MB
+* `.igd`: 183MB
 
-Converting the `.vcf.gz` to `.bgen` (via qctool) took 23 minutes, but converting to `.igd` only took 3 minutes. Furthermore, iteratively accessing all the variants (and genotype data) in the `.igd` file was ~`5x` faster than accessing the same data in the `.vcf.gz` file.
-
-All that to say: `.igd` is a good format if you want fast access to variants in a relatively small file.
-
+Converting the `.vcf.gz` to `.bgen` (via qctool) took 23 minutes, but converting to `.igd` only took 3 minutes. Furthermore, iteratively accessing all the variants (and genotype data) in the `.igd` file was approximately `15x` faster than accessing the same data in the `.vcf.gz` file (using `picovcf`). On Biobank-scale real datasets, IGD is on average 3.5x smaller than `.vcf.gz`.

--- a/examples/igdpp.cpp
+++ b/examples/igdpp.cpp
@@ -14,7 +14,7 @@
 
 using namespace picovcf;
 
-inline void emitAllele(IndexT alleleIndex, std::ostream& out) {
+inline void emitAllele(VariantT alleleIndex, std::ostream& out) {
     if (alleleIndex == MISSING_VALUE) {
         out << "? ";
     } else {

--- a/examples/vcfconv.cpp
+++ b/examples/vcfconv.cpp
@@ -17,6 +17,6 @@ int main(int argc, char *argv[]) {
 
     const std::string infile(argv[1]);
     const std::string outfile(argv[2]);
-    vcfToIGD(infile, outfile);
+    vcfToIGD(infile, outfile, "", true);
     return 0;
 }

--- a/examples/vcfpp.cpp
+++ b/examples/vcfpp.cpp
@@ -12,7 +12,7 @@
 
 using namespace picovcf;
 
-inline void emitAllele(IndexT alleleIndex, std::ostream& out) {
+inline void emitAllele(VariantT alleleIndex, std::ostream& out) {
     if (alleleIndex == MISSING_VALUE) {
         out << "? ";
     } else {
@@ -55,8 +55,8 @@ int main(int argc, char *argv[]) {
             VCFVariantView variant = vcf.currentVariant();
             IndividualIteratorGT iterator = variant.getIndividualIterator();
             while (iterator.hasNext()) {
-                IndexT allele1 = 0;
-                IndexT allele2 = 0;
+                VariantT allele1 = 0;
+                VariantT allele2 = 0;
                 bool isPhased = iterator.getAlleles(allele1, allele2);
                 if (!isPhased) {
                     std::cerr << "Cannot create a matrix for unphased data" << std::endl;

--- a/picovcf.hpp
+++ b/picovcf.hpp
@@ -1042,7 +1042,7 @@ public:
         }
         auto prevFilePosition = this->getFilePosition();
         const size_t numIndividuals =
-            std::min(totalIndividuals, individualRange.second) - individualRange.first;
+            std::min<size_t>(totalIndividuals, individualRange.second) - individualRange.first;
         result.firstIndividual = individualRange.first;
         result.sampleToMutation.clear();
         result.parsedVariants.clear();
@@ -1060,7 +1060,7 @@ public:
 
                 for (size_t i = 0; i < (individualRange.second - individualRange.first)
                                    && iterator.hasNext(); i++, iterator.next()) {
-                    size_t allele1 = 0, allele2 = 0;
+                    VariantT allele1 = 0, allele2 = 0;
                     iterator.getAlleles(allele1, allele2, /*moveNext=*/false);
                     if (result.sampleToMutation.empty()) {
                         result.isDiploid = (allele2 != NOT_DIPLOID);

--- a/test/test_helpers.cpp
+++ b/test/test_helpers.cpp
@@ -56,7 +56,6 @@ TEST(Helpers, Split) {
 
 
 TEST(Helper, SerializeAlleleBits) {
-    using SampleList = std::vector<IndexT>;
     InMemBuffer buffer(DEFAULT_BUFFER_SIZE);
     std::ostream outStream(&buffer);
 
@@ -64,21 +63,21 @@ TEST(Helper, SerializeAlleleBits) {
     ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0xFF);
     ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x00);
     auto sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 8);
-    ASSERT_EQ(sampleSet, SampleList({0, 1, 2, 3, 4, 5, 6, 7}));
+    ASSERT_EQ(sampleSet, IGDSampleList({0, 1, 2, 3, 4, 5, 6, 7}));
 
     buffer.reset(DEFAULT_BUFFER_SIZE);
     writeAllelesAsOnes(outStream, {0, 1, 2, 5, 6, 7, 8}, 10);
     ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0xE7);
     ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x80);
     sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 10);
-    ASSERT_EQ(sampleSet, SampleList({0, 1, 2, 5, 6, 7, 8}));
+    ASSERT_EQ(sampleSet, IGDSampleList({0, 1, 2, 5, 6, 7, 8}));
 
     buffer.reset(DEFAULT_BUFFER_SIZE);
     writeAllelesAsOnes(outStream, {15}, 16);
     ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0x00);
     ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x01);
     sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 16);
-    ASSERT_EQ(sampleSet, SampleList({15}));
+    ASSERT_EQ(sampleSet, IGDSampleList({15}));
 }
 
 TEST(Helper, BufferedReader) {

--- a/test/test_helpers.cpp
+++ b/test/test_helpers.cpp
@@ -60,21 +60,21 @@ TEST(Helper, SerializeAlleleBits) {
     InMemBuffer buffer(DEFAULT_BUFFER_SIZE);
     std::ostream outStream(&buffer);
 
-    writeAllelesAsOnes(outStream, 1, {1, 1, 1, 1, 1, 1, 1, 1});
+    writeAllelesAsOnes(outStream, {0, 1, 2, 3, 4, 5, 6, 7}, 8);
     ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0xFF);
     ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x00);
     auto sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 8);
     ASSERT_EQ(sampleSet, SampleList({0, 1, 2, 3, 4, 5, 6, 7}));
 
     buffer.reset(DEFAULT_BUFFER_SIZE);
-    writeAllelesAsOnes(outStream, 2, {2, 2, 2, 0, 1, 2, 2, 2, 2, 0});
+    writeAllelesAsOnes(outStream, {0, 1, 2, 5, 6, 7, 8}, 10);
     ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0xE7);
     ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x80);
     sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 10);
     ASSERT_EQ(sampleSet, SampleList({0, 1, 2, 5, 6, 7, 8}));
 
     buffer.reset(DEFAULT_BUFFER_SIZE);
-    writeAllelesAsOnes(outStream, 3, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3});
+    writeAllelesAsOnes(outStream, {15}, 16);
     ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0x00);
     ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x01);
     sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 16);

--- a/test/test_igd.cpp
+++ b/test/test_igd.cpp
@@ -14,8 +14,16 @@ TEST(IGD, MissingData) {
 
     IGDData igdFile(igdFileName);
 
-    ASSERT_EQ(igdFile.numVariants(), 7); // 2 of the variants have multiple alt alleles
-    const auto& missingData = igdFile.getMissingData();
+    ASSERT_EQ(igdFile.numVariants(), 12); // 2 of the variants have multiple alt alleles
+    size_t numMissing = 0;
+    for (size_t i = 0; i < igdFile.numVariants(); i++) {
+        bool isMissing = false;
+        igdFile.getPosition(i, isMissing);
+        auto sampleList = igdFile.getSamplesWithAlt(i);
+        if (isMissing) {
+            numMissing++;
+        }
+    }
     // Every variant is missing
-    ASSERT_EQ(missingData.size(), 5);
+    ASSERT_EQ(numMissing, 5);
 }

--- a/test/test_valid_vcf.cpp
+++ b/test/test_valid_vcf.cpp
@@ -48,8 +48,8 @@ TEST(ValidVCF, SpecExample) {
     ASSERT_TRUE(variant1.hasGenotypeData());
 
     // Check all individuals of the first variant
-    size_t allele1 = MISSING_VALUE;
-    size_t allele2 = MISSING_VALUE;
+    VariantT allele1 = MISSING_VALUE;
+    VariantT allele2 = MISSING_VALUE;
     bool isPhased;
     IndividualIteratorGT iterator = variant1.getIndividualIterator();
     // Do the first individual twice in a row.

--- a/test/test_valid_vcf.cpp
+++ b/test/test_valid_vcf.cpp
@@ -29,8 +29,8 @@ TEST(ValidVCF, SpecExample) {
         VCFVariantView variant = vcf.currentVariant();
         IndividualIteratorGT iterator = variant.getIndividualIterator();
         while (iterator.hasNext()) {
-            IndexT allele1 = 0;
-            IndexT allele2 = 0;
+            VariantT allele1 = 0;
+            VariantT allele2 = 0;
             iterator.getAlleles(allele1, allele2);
         }
     }
@@ -93,9 +93,7 @@ TEST(ValidVCF, SpecExample) {
     ASSERT_TRUE(variant4.hasGenotypeData());
 }
 
-using SampleList = std::vector<IndexT>;
-
-static bool hasSample(const SampleList& samples, IndexT id) {
+static bool hasSample(const IGDSampleList& samples, SampleT id) {
     for (auto sampleId : samples) {
         if (id == sampleId) {
             return true;
@@ -133,10 +131,10 @@ TEST(ValidVCF, Indexable) {
         ASSERT_EQ(variant.getPosition(), indexableData.getPosition(index, isMissing));
         auto sampleSet = indexableData.getSamplesWithAlt(index);
         IndividualIteratorGT individualIt = variant.getIndividualIterator();
-        size_t sampleIndex = 0;
+        SampleT sampleIndex = 0;
         while (individualIt.hasNext()) {
-            IndexT allele1 = 255;
-            IndexT allele2 = 255;
+            VariantT allele1 = 255;
+            VariantT allele2 = 255;
             individualIt.getAlleles(allele1, allele2);
             if (allele1 == 1) {
                 if (!hasSample(sampleSet, sampleIndex)) {

--- a/test/test_valid_vcf.cpp
+++ b/test/test_valid_vcf.cpp
@@ -120,7 +120,8 @@ TEST(ValidVCF, Indexable) {
     ASSERT_EQ(indexableData.numVariants(), EXPECT_VARIANTS);
     ASSERT_EQ(indexableData.numIndividuals(), EXPECT_INDIVIDUALS);
     ASSERT_EQ(indexableData.numSamples(), 2*EXPECT_INDIVIDUALS);
-    ASSERT_EQ(indexableData.getPosition(0), 55829);
+    bool _ignore = false;
+    ASSERT_EQ(indexableData.getPosition(0, _ignore), 55829);
 
     size_t index = 0;
     vcf.seekBeforeVariants();
@@ -128,7 +129,8 @@ TEST(ValidVCF, Indexable) {
         vcf.nextVariant();
         VCFVariantView& variant = vcf.currentVariant();
         ASSERT_FALSE(variant.getAltAlleles().size() > 1);
-        ASSERT_EQ(variant.getPosition(), indexableData.getPosition(index));
+        bool isMissing = false;
+        ASSERT_EQ(variant.getPosition(), indexableData.getPosition(index, isMissing));
         auto sampleSet = indexableData.getSamplesWithAlt(index);
         IndividualIteratorGT individualIt = variant.getIndividualIterator();
         size_t sampleIndex = 0;
@@ -137,6 +139,10 @@ TEST(ValidVCF, Indexable) {
             IndexT allele2 = 255;
             individualIt.getAlleles(allele1, allele2);
             if (allele1 == 1) {
+                if (!hasSample(sampleSet, sampleIndex)) {
+                    std::cout << "Variant " << index << " failed: ";
+                    std::cout << "missing sample " << sampleIndex << "\n";
+                }
                 ASSERT_TRUE(hasSample(sampleSet, sampleIndex));
             }
             sampleIndex++;


### PR DESCRIPTION
Rework the IGD file format a bit. This simplifies things in that the missing data is now handled less "specially" than before and is more likely to be scalable.
* The index is now a separate table at the end of the file. This speeds up file access dramatically for large files.
* Each "row" is now represented by either a bitvector or a sample list, depending on the sparsity of the row.

Typically this produces files that are at least 5x smaller than IGD format v2 was. For real biobank-scale data the size decrease is even more dramatic: there are so many low-frequency variants in such datasets that for one example more than 95% of variants will be represented sparsely now.