### PR TITLE
Update README, make release build the default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(FUZZING_SUPPORT "Build for fuzzing; only abort on true failures, not inva
 option(BUILD_EXAMPLES "Build example tools" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Debug")
+  set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 # Check for optional POSIX functions

--- a/README.md
+++ b/README.md
@@ -22,15 +22,28 @@ See the [vcfpp.cpp](https://github.com/aprilweilab/picovcf/blob/main/examples/vc
 
 When building code that uses `picovcf.hpp`, define `VCF_GZ_SUPPORT=1` (`-DVCF_GZ_SUPPORT=1` on most compiler command lines) to enable zlib support for compressed VCF files.
 
-## Build and run the tests
+## Build and run the tests/tools
 
-picovcf does not need to be built to be used, since it is a single header that gets built as part of your project. However, if you want to build and run the unit tests, do the following:
+picovcf does not need to be built to be used, since it is a single header that gets built as part of your project. However, if you want to build the tests and tools:
 
 ```
 cd picovcf
 mkdir build && cd build
-cmake ..
+cmake .. -DENABLE_VCF_GZ=ON
 make
+```
+
+**NOTE**: `-DENABLE_VCF_GZ=ON` is optional, and links against `libz` in case you want to support `.vcf.gz` (compressed) files in the tools.
+
+To convert from a `.vcf` or `.vcf.gz` file to `.igd`, run:
+```
+./vcfconv <vcf filename> <output IGD filename>
+```
+
+To view basic statistics for an IGD file, use `igdpp`. Some commands to try are `./igdpp stats <igd file>` or `./igdpp range_stats <igd file>`.
+
+Finally, to run the unit tests:
+```
 EXAMPLE_VCFS=../test/example_vcfs/ ./picovcf_test
 ```
 
@@ -60,3 +73,12 @@ For example, the following are from chromosome 22 of a real dataset:
 * `.igd`: 183MB
 
 Converting the `.vcf.gz` to `.bgen` (via qctool) took 23 minutes, but converting to `.igd` only took 3 minutes. Furthermore, iteratively accessing all the variants (and genotype data) in the `.igd` file was approximately `15x` faster than accessing the same data in the `.vcf.gz` file (using `picovcf`). On Biobank-scale real datasets, IGD is on average 3.5x smaller than `.vcf.gz`.
+
+### How do I use IGD in my project?
+
+* Clone [picovcf](https://github.com/aprilweilab/picovcf) and follow the instructions in this README to build the example tools for that library.
+  * If you want to be able to convert `.vcf.gz` (compressed VCF) to IGD, make sure you build with `-DENABLE_VCF_GZ=ON`
+* One of the built tools will be `vcfconf`, which converts from VCF to IGD. Run `vcfconv <vcf file> <igd file>` to convert your data to IGD.
+* Do one of the following:
+  * If your project is C++, copy [picovcf.hpp](https://github.com/aprilweilab/picovcf/blob/main/picovcf.hpp) into your project, `#include` it somewhere and then use according to the [documentation](https://picovcf.readthedocs.io/en/latest/)
+  * If your project is Python, clone [pyigd](https://github.com/aprilweilab/pyigd/) and install it per the [README instructions](https://github.com/aprilweilab/pyigd/blob/main/README.md).


### PR DESCRIPTION
A bit more context on how to use IGD in your project, i.e. converting from VCF, supporting vcf.gz, and cross-reference to the Python parser.