### PR TITLE
Reduce sparsity threshold, code cleanup, igdcp example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,9 @@ if(${BUILD_EXAMPLES})
   # igdpp utility
   add_executable(igdpp examples/igdpp.cpp)
   target_link_libraries(igdpp ${LIBRARIES_TO_LINK})
+  # igdcp utility
+  add_executable(igdcp examples/igdcp.cpp)
+  target_link_libraries(igdcp ${LIBRARIES_TO_LINK})
   if (${ENABLE_VCF_GZ})
     # gzcat utility
     add_executable(gzcat examples/gzcat.cpp)

--- a/examples/igdcp.cpp
+++ b/examples/igdcp.cpp
@@ -1,0 +1,51 @@
+/* Copy from one IGD file to another.
+ *
+ * Usage:
+ *  igdcp <infile> <outfile>
+ */
+#include <iostream>
+#include <cmath>
+#include <iomanip>
+
+#include "picovcf.hpp"
+
+using namespace picovcf;
+
+int main(int argc, char *argv[]) {
+    std::cout << std::fixed << std::setprecision(4);
+    if (argc < 3) {
+        std::cerr << "Usage: igdcp <infile> <outfile>" << std::endl;
+        return 1;
+    }
+
+    const std::string infile(argv[1]);
+    const std::string outfile(argv[2]);
+
+    IGDData igd(infile);
+    uint64_t numIndividuals = igd.numIndividuals();
+    uint64_t ploidy = igd.getPloidy();
+
+    // Example of copying data from one IGD to another. Copy all the variants and then write the
+    // index and optional metadata at the end. We write the header twice because it contains file
+    // pointers that get updated by the other "writeXXX()" methods.
+    std::ofstream igdOutfile(outfile, std::ios::binary);
+    IGDWriter writer(ploidy, igd.numIndividuals(), igd.isPhased());
+    writer.writeHeader(igdOutfile, infile, igd.getDescription());
+    for (size_t i = 0; i < igd.numVariants(); i++) {
+        bool isMissing = false;
+        const auto position = igd.getPosition(i, isMissing);
+        writer.writeVariantSamples(igdOutfile,
+                                   position,
+                                   igd.getRefAllele(i),
+                                   igd.getAltAllele(i),
+                                   igd.getSamplesWithAlt(i),
+                                   isMissing);
+    }
+    writer.writeIndex(igdOutfile);
+    writer.writeVariantInfo(igdOutfile);
+    writer.writeIndividualIds(igdOutfile, igd.getIndividualIds());
+    igdOutfile.seekp(0);
+    writer.writeHeader(igdOutfile, infile, igd.getDescription());
+
+    return 0;
+}

--- a/examples/igdpp.cpp
+++ b/examples/igdpp.cpp
@@ -4,7 +4,7 @@
  * Usage:
  *  igdpp <command> <file>
  *
- * where command is one of ["stats", "range_start"]
+ * where command is one of ["freq", "individuals", "stats", "sites", "range_start"]
  */
 #include <iostream>
 #include <cmath>
@@ -44,6 +44,23 @@ int main(int argc, char *argv[]) {
         std::cout << "  Genome range: " << igd.getPosition(0)
                                         << "-" << igd.getPosition(igd.numVariants()-1) << std::endl;
         std::cout << "  Has individual IDs? " << (igd.getIndividualIds().empty() ? "No" : "Yes") << std::endl;
+    } else if (command == "sites") {
+        size_t lastPosition = std::numeric_limits<size_t>::max();
+        size_t sites = 0;
+        for (size_t i = 0; i < igd.numVariants(); i++) {
+            bool isMissing = false;
+            auto pos = igd.getPosition(i, isMissing);
+            if (pos != lastPosition) {
+                sites++;
+                lastPosition = pos;
+            }
+        }
+        std::cout << "Unique sites: " << sites << std::endl;
+    } else if (command == "individuals") {
+        std::vector<std::string> individualIds = igd.getIndividualIds();
+        for (size_t i = 0; i < individualIds.size(); i++) {
+            std::cout << i << ": " << individualIds[i] << std::endl;
+        }
     } else if (command == "range_stats") {
         std::cout << "Stats for " << filename << std::endl;
         bool _ignore = false;

--- a/examples/vcfconv.cpp
+++ b/examples/vcfconv.cpp
@@ -1,7 +1,7 @@
 /* Convert VCF to IIGT.
  *
  * Usage:
- *  vcfconv <vcf-file> <output-file>
+ *  vcfconv <vcf-file> <output-file> -copy-ids
  */
 #include <iostream>
 
@@ -11,12 +11,22 @@ using namespace picovcf;
 
 int main(int argc, char *argv[]) {
     if (argc < 3) {
-        std::cerr << "Please pass in an input file and output file name" << std::endl;
+        std::cerr << "Usage: vcfconv <vcf-file> <output-file> [-copy-ids]" << std::endl;
         return 1;
     }
 
+    bool emitIndividualIds = false;
     const std::string infile(argv[1]);
     const std::string outfile(argv[2]);
-    vcfToIGD(infile, outfile, "", true);
+    if (argc > 3) {
+        std::string arg3 = argv[3];
+        if (arg3 == "-copy-ids") {
+            emitIndividualIds = true;
+        } else {
+            std::cerr << "Unrecognized flag \"" << arg3 << "\"" << std::endl;
+            return 1;
+        }
+    }
+    vcfToIGD(infile, outfile, "", true, emitIndividualIds);
     return 0;
 }


### PR DESCRIPTION
* Reduce the sparsity threshold to 1/32. We store each sample ID as 32-bits, which means that as long as the density of samples for a variant is <1/32 it will be stored smaller sparsely than as a bitvector (1 bit per sample, for all N samples).
* Just add some inline helper functions to cleanup common i/o tasks.
* Add new igdcp example which just copies from one IGD to another.