### PR TITLE
File format V4: shrink strings, add variant ids (backwards compat)

### DIFF
--- a/IGD.FORMAT.md
+++ b/IGD.FORMAT.md
@@ -14,56 +14,60 @@ starts at the 0th byte of the file, and is 128 bytes in size:
 | 40 | 8 | flags | Bitwise flags; the only one right now is 0x1, which if set means the data is phased |
 | 48 | 8 | filePosIndex | The file position of the index describing the genomic and file positions of all variants. |
 | 56 | 8 | filePosVariants | The file position of the first variant data entry - this data does not contain genotypes, just information about variants |
-| 64 | 8 | filePosIndividualIds | The file position of the identifiers (labels) for individuals, left at 0 if there are no identifiers |
-| 72 | 56 | reserved | Reserved data for future fields. MUST be set to 0 when an IGD file is created |
+| 64 | 8 | filePosIndividualIds | The file position of the identifiers (labels) for individuals, set to 0 if there are no identifiers |
+| 72 | 8 | filePosVariantIds | The file position of the identifiers (labels) for variants, set to 0 if there are no identifiers |
+| 80 | 48 | reserved | Reserved data for future fields. MUST be set to 0 when an IGD file is created |
 
-All variable-sized strings in the file format are encoded as an 8-byte length `L`, followed by `L` bytes containing the string contents.
+All variable-sized strings in the file format are encoded as an 4-byte length `L`, followed by `L` bytes containing the string contents.
+All sample-related quantities are 32-bit (allowing a maximum of ~4 billion samples, ~2 billion individuals). All variant-related quantities are 64-bit.
+All indexes are 0-based, so `0` represents the first sample, first variant, etc.
 
 Immediately after the header are two variable-sized string fields:
 1. "Source": where the IGD file data came from (often information about data conversion).
 2. "Description": just a general field to hold information about the dataset.
 
-### SizedList Samples
-
-Sparse representation of the samples as a list of indexes. If the list contains value `i`, then the `ith` sample has the alternate allele represented by the particular row.
-
-The layout is:
-  * The 8-byte number of samples (NOT individuals) that are in the list.
-  * An 8-byte index that corresponds to the sample in the list: this value is between `0...((ploidy*numIndividuals)-1)`.
-
-### BitVector Samples
-
-Non-sparse representation of the samples as a bitvector. A `1` indicates the alternate allele, a `0` represents the reference allele. There are `ploidy*numIndividuals` bits, rounded up to the next byte. The end of the row can by found then by `startingPosition + (((numIndividuals * ploidy) + 7) / 8)`. Bit `startingPosition + i` refers to the `ith` sample.
-
-## Sample Rows
+## Sample Rows (REQUIRED)
 
 Immediately following the header and string fields is the sample row data. This data should be accessed only via the corresponding `IndexEntry`, which describes the layout.
 
 Note that we only support one alternate per variant, which means that converting from a file format like VCF requires "expanding" the variants. A single VCF variant with `N` alternate alleles will become `N` IGD variants.
 
-The above are the only required-to-be-consecutive parts of the IGD file. The remaining sections can be anywhere in the file (_after_ the above), and use the header fields to indicate where they are.
+The header, string firleds, and sample rows are the only required-to-be-contiguous parts of the IGD file. The remaining sections can be anywhere in the file (_after_ the above), and use the header fields to indicate where they are.
+Each row of sample data corresonds to the list of samples that have the alternate allele of the given (bi-allelic) variant. When the row is flagged as a "missing data row", the sample list corresponds to samples that do not have an allele for the given site, in the dataset. Each row of sample data can be encoded as either a "SizedList" or "BitVector" -- see below.
 
-## Common Datatypes
+### SizedList Samples
 
-## Variant Information
+The "SizedList" is a sparse representation of the samples as a list of indexes. If the list contains value `i`, then the `ith` sample has the alternate allele represented by the particular row.
 
-At position identified by `filePosVariants` in the header. Has `numVariants` entries, each of which is:
+The layout is:
+  * A 4-byte unsigned integer: the number of samples `k` (NOT individuals) that are in the list.
+  * `k` consecutive 4-byte unsigned integers: the index that corresponds to the sample in the list: this value is between `0...((ploidy*numIndividuals)-1)`.
+
+### BitVector Samples
+
+The non-sparse representation of the samples as a bitvector. A `1` indicates the alternate allele, a `0` represents the reference allele. There are `ploidy*numIndividuals` bits, rounded up to the next byte (i.e., `ceil( (ploidy*numIndividuals) / 8)`). The end of the row can by found by `startingPosition + (((numIndividuals * ploidy) + 7) / 8)`. Bit `startingPosition + i` refers to the `ith` sample.
+
+## Variant Information (REQUIRED)
+
+The string values for alleles are located in the file at `filePosVariants` in the header. Has `numVariants` entries, each of which is a pair of string:
 * Variable-sized string: Reference allele value.
 * Variable-sized string: Alternate allele value.
 
 Note that we only support one alternate per variant, which means that converting from a file format like VCF requires "expanding" the variants. A single VCF variant with `N` alternate alleles will become `N` IGD variants.
 
-## Individual Identifiers
+## Individual Identifiers (OPTIONAL)
 
-Identifiers for each individual are at `filePosIndividualIds` if it is not `0`. This data has:
+Identifiers for each individual are located in the file at `filePosIndividualIds` if it is not `0`. This data has:
 * An 8-byte value indicating how many labels there are.
 * A variable-sized string for each label.
 
-## Missing Data
+## Variant Identifiers (OPTIONAL)
 
-At position identified by `filePosMissingData` in the header. Has less-than-or-equal-to `numVariants` entries, each of which is a `SizedList`. Should be accessed via the `IndexEntry`, as otherwise you don't know which variant each row of data is for (since the `filePosMissingRow` in `IndexEntry` can be `0`, meaning there is none of that variant).
+Identifiers for each variant are located in the file at `filePosVariantIds` if it is not `0`. This data has:
+* An 8-byte value indicating how many labels there are.
+* A variable-sized string for each label.
 
-## The Index
+## The Index (REQUIRED)
 
 At position identified by `filePosIndex` is the file index. There are `numVariants` consecutive `IndexEntry`s following this layout:
 | Byte Offset | Byte Size | Name | Description |

--- a/examples/igdcp.cpp
+++ b/examples/igdcp.cpp
@@ -44,6 +44,7 @@ int main(int argc, char *argv[]) {
     writer.writeIndex(igdOutfile);
     writer.writeVariantInfo(igdOutfile);
     writer.writeIndividualIds(igdOutfile, igd.getIndividualIds());
+    writer.writeVariantIds(igdOutfile, igd.getVariantIds());
     igdOutfile.seekp(0);
     writer.writeHeader(igdOutfile, infile, igd.getDescription());
 

--- a/examples/igdpp.cpp
+++ b/examples/igdpp.cpp
@@ -4,7 +4,7 @@
  * Usage:
  *  igdpp <command> <file>
  *
- * where command is one of ["freq", "individuals", "stats", "sites", "range_start"]
+ * where command is one of ["freq", "individuals", "stats", "sites", "range_start", "variants"]
  */
 #include <iostream>
 #include <cmath>
@@ -60,6 +60,11 @@ int main(int argc, char *argv[]) {
         std::vector<std::string> individualIds = igd.getIndividualIds();
         for (size_t i = 0; i < individualIds.size(); i++) {
             std::cout << i << ": " << individualIds[i] << std::endl;
+        }
+    } else if (command == "variants") {
+        std::vector<std::string> variantIds = igd.getVariantIds();
+        for (size_t i = 0; i < variantIds.size(); i++) {
+            std::cout << i << ": " << variantIds[i] << std::endl;
         }
     } else if (command == "range_stats") {
         std::cout << "Stats for " << filename << std::endl;

--- a/examples/vcfconv.cpp
+++ b/examples/vcfconv.cpp
@@ -16,17 +16,19 @@ int main(int argc, char *argv[]) {
     }
 
     bool emitIndividualIds = false;
+    bool emitVariantIds = false;
     const std::string infile(argv[1]);
     const std::string outfile(argv[2]);
     if (argc > 3) {
         std::string arg3 = argv[3];
         if (arg3 == "-copy-ids") {
             emitIndividualIds = true;
+            emitVariantIds = true;
         } else {
             std::cerr << "Unrecognized flag \"" << arg3 << "\"" << std::endl;
             return 1;
         }
     }
-    vcfToIGD(infile, outfile, "", true, emitIndividualIds);
+    vcfToIGD(infile, outfile, "", true, emitIndividualIds, emitVariantIds);
     return 0;
 }


### PR DESCRIPTION
This is a backwards compatible file-format change. I.e., the IGD parser will load both V3 and V4 files. V4 changes:
* The lengths of strings is encoded as 32-bit integers instead of 64-bit. We don't expect any strings longer than 4 billion chars..
* Similar to individual IDs, variant IDs can be copied over from VCF files. Generally I'd recommend putting _all_ meta-data in a separate file (JSON or similar). You can do everything you need by selecting a set of variants/samples to operate on, then use the IGD data, and then post-process/display results using the separate metadata. There is no reason (other than convenience of having a single file) to keep meta-data with the actual genotype data.