### PR TITLE
Adjust numIndividuals in the header (forward + backwards compat)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,10 @@ FROM ubuntu:22.04
 
 RUN apt update
 # For the base build
-RUN apt install -y git build-essential cmake
-# For build the documentation
-RUN apt install -y python3 python3-setuptools python3-pip doxygen
+RUN apt install -y git build-essential cmake \
+        python3 python3-setuptools python3-pip doxygen \
+        zlib1g-dev time
 RUN pip3 install wheel sphinx breathe sphinx-rtd-theme
-# For .vcf.gz support
-RUN apt install -y zlib1g-dev
 
 COPY . /picovcf_src
 RUN cd /picovcf_src \
@@ -21,4 +19,5 @@ RUN cd /picovcf_src \
     && cd docker_build \
     && cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_VCF_GZ=ON \
     && make -j \
-    && DOC_BUILD_DIR=$PWD sphinx-build -c ../doc/ -b html -Dbreathe_projects.picovcf=$PWD/doc/xml ../doc/ $PWD/doc/sphinx/
+    && DOC_BUILD_DIR=$PWD sphinx-build -c ../doc/ -b html -Dbreathe_projects.picovcf=$PWD/doc/xml ../doc/ $PWD/doc/sphinx/ \
+    && cp igdtools /usr/bin/

--- a/IGD.FORMAT.md
+++ b/IGD.FORMAT.md
@@ -10,7 +10,8 @@ starts at the 0th byte of the file, and is 128 bytes in size:
 | 16 | 4 | ploidy | Ploidy of each individual, >= 1 |
 | 20 | 4 | sparseThreshold | Threshold that determines whether a sample list is stored as a bitvector or sparse list. |
 | 24 | 8 | numVariants | The number of total variants in the file |
-| 32 | 8 | numIndividuals | The number of total individuals in the file |
+| 32 | 4 | numIndividuals | The number of total individuals in the file |
+| 36 | 4 | reserved | Reserved for future field. MUST be set to 0 when an IGD file is created |
 | 40 | 8 | flags | Bitwise flags; the only one right now is 0x1, which if set means the data is phased |
 | 48 | 8 | filePosIndex | The file position of the index describing the genomic and file positions of all variants. |
 | 56 | 8 | filePosVariants | The file position of the first variant data entry - this data does not contain genotypes, just information about variants |

--- a/picovcf.hpp
+++ b/picovcf.hpp
@@ -1318,7 +1318,8 @@ public:
         uint32_t ploidy;                // Ploidy of every individual.
         uint32_t sparseThreshold;       // Number of samples below which we store a variant sparsely.
         uint64_t numVariants;           // Total number of variants.
-        uint64_t numIndividuals;        // Total number of individuals.
+        uint32_t numIndividuals;        // Total number of individuals.
+        uint32_t unusedCenter;          // Unused
         uint64_t flags;                 // Flags that indicate properties of the dataset.
         uint64_t filePosIndex;          // Byte offset in the file where the variant rows start.
         uint64_t filePosVariants;       // Byte offset in the file where the variant allele information start.
@@ -1377,7 +1378,7 @@ public:
      * The number of individuals represented in the genotype data.
      * @return Number of individuals.
      */
-    VariantT numIndividuals() const {
+    SampleT numIndividuals() const {
         return m_header.numIndividuals;
     }
 
@@ -1690,7 +1691,7 @@ public:
      * @param[in] isPhased True if the data is phased, false otherwise.
      */
     IGDWriter(uint32_t ploidy,
-              uint64_t numIndividuals,
+              uint32_t numIndividuals,
               bool isPhased)
             : m_header({
                 IGDData::IGD_MAGIC,
@@ -1699,6 +1700,7 @@ public:
                 IGDData::DEFAULT_SPARSE_THRESHOLD,
                 0,
                 numIndividuals,
+                0,
                 isPhased ? IGDData::IGD_PHASED : 0x0,
                 0,
                 0,


### PR DESCRIPTION
We won't ever need 64-bits for numIndividuals, since sample indexes are stored with 32-bits.