### PR TITLE
Buffer writes (IGD), which makes the bit-vector algorithm simpler

### DIFF
--- a/test/test_helpers.cpp
+++ b/test/test_helpers.cpp
@@ -56,27 +56,25 @@ TEST(Helpers, Split) {
 
 
 TEST(Helper, SerializeAlleleBits) {
-    InMemBuffer buffer(DEFAULT_BUFFER_SIZE);
-    std::ostream outStream(&buffer);
+    std::vector<uint8_t> buffer;
 
-    writeAllelesAsOnes(outStream, {0, 1, 2, 3, 4, 5, 6, 7}, 8);
-    ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0xFF);
-    ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x00);
-    auto sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 8);
+    writeAllelesAsOnes(buffer, {0, 1, 2, 3, 4, 5, 6, 7}, 8);
+    ASSERT_EQ((uint8_t)buffer.at(0), 0xFF);
+    auto sampleSet = getSamplesWithAlt((const uint8_t*)buffer.data(), 8);
     ASSERT_EQ(sampleSet, IGDSampleList({0, 1, 2, 3, 4, 5, 6, 7}));
 
-    buffer.reset(DEFAULT_BUFFER_SIZE);
-    writeAllelesAsOnes(outStream, {0, 1, 2, 5, 6, 7, 8}, 10);
-    ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0xE7);
-    ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x80);
-    sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 10);
+	buffer.clear();
+    writeAllelesAsOnes(buffer, {0, 1, 2, 5, 6, 7, 8}, 10);
+    ASSERT_EQ((uint8_t)buffer.at(0), 0xE7);
+    ASSERT_EQ((uint8_t)buffer.at(1), 0x80);
+    sampleSet = getSamplesWithAlt((const uint8_t*)buffer.data(), 10);
     ASSERT_EQ(sampleSet, IGDSampleList({0, 1, 2, 5, 6, 7, 8}));
 
-    buffer.reset(DEFAULT_BUFFER_SIZE);
-    writeAllelesAsOnes(outStream, {15}, 16);
-    ASSERT_EQ((uint8_t)buffer.m_buffer[0], 0x00);
-    ASSERT_EQ((uint8_t)buffer.m_buffer[1], 0x01);
-    sampleSet = getSamplesWithAlt((const uint8_t*)&buffer.m_buffer[0], 16);
+    buffer.clear();
+    writeAllelesAsOnes(buffer, {15}, 16);
+    ASSERT_EQ((uint8_t)buffer.at(0), 0x00);
+    ASSERT_EQ((uint8_t)buffer.at(1), 0x01);
+    sampleSet = getSamplesWithAlt((const uint8_t*)buffer.data(), 16);
     ASSERT_EQ(sampleSet, IGDSampleList({15}));
 }
 


### PR DESCRIPTION
IGD->IGD conversion is about twice as faster with this change, on simulated datasets that have a lot of HF variants.