### PR TITLE
Bug fix "forceUnphased" for VCF, add dropUnphased option

### DIFF
--- a/igdtools/igdtools.cpp
+++ b/igdtools/igdtools.cpp
@@ -73,6 +73,7 @@ int main(int argc, char* argv[]) {
         parser, "forceUnphased", "Force output file to be unphased, regardless of input.", {"force-unphased"});
     args::Flag dropMulti(
         parser, "dropMulti", "Drop multi-allelic sites (more than one alternate allele).", {"drop-multi"});
+    args::Flag dropUnphased(parser, "dropUnphased", "Drop sites containing unphased data.", {"drop-unphased"});
     args::ValueFlag<std::string> handlePloidy(
         parser,
         "handlePloidy",
@@ -131,10 +132,19 @@ int main(int argc, char* argv[]) {
         const bool emitVariantIds = !noVariantIds;
         const PloidyHandling hploidy =
             handlePloidy ? (*handlePloidy == "force-diploid" ? PH_FORCE_DIPLOID : PH_STRICT) : PH_STRICT;
-        vcfToIGD(*infile, *outfile, description, true, emitIndividualIds, emitVariantIds, forceUnphasedArg, hploidy);
+        vcfToIGD(*infile,
+                 *outfile,
+                 description,
+                 true,
+                 emitIndividualIds,
+                 emitVariantIds,
+                 forceUnphasedArg,
+                 hploidy,
+                 dropUnphased);
         return 0;
     } else {
         ONLY_SUPPORTED_FOR_VCF(handlePloidy, "--handle-ploidy");
+        ONLY_SUPPORTED_FOR_VCF(dropUnphased, "--drop-unphased");
     }
 
     // Not a VCF, then assume it is IGD and load the header.

--- a/test/endtoend/run_tests.py
+++ b/test/endtoend/run_tests.py
@@ -44,5 +44,25 @@ class TestIgdTools(unittest.TestCase):
             quiet_del("msprime.example.igd")
             quiet_del("msprime.example.dephased.igd")
 
+    def test_unphased_from_vcf(self):
+        # Same as test_unphased_from_igd, except we unphase the file while converting from VCF
+
+        # Convert unphased VCF to IGD
+        run(["igdtools", input("unphased.example.vcf"), "--out", "unphased2.example.igd"])
+
+        # Convert phased VCF to IGD, then convert phased IGD to unphased IGD
+        run(["igdtools", input("msprime.example.vcf"), "--force-unphased", "--out",  "msprime.example.dephased2.igd"])
+
+        unphased_result = run(["igdtools", "unphased2.example.igd", "--alleles"]).decode("utf-8")
+        dephased_result = run(["igdtools", "msprime.example.dephased2.igd", "--alleles"]).decode("utf-8")
+
+        self.assertEqual(unphased_result, dephased_result)
+        line_count = len(list(filter(lambda x: len(x.strip()) > 0, unphased_result.split("\n"))))
+        self.assertEqual(line_count, 8)
+
+        if CLEANUP:
+            quiet_del("unphased2.example.igd")
+            quiet_del("msprime.example.dephased2.igd")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* `--force-unphased` worked fine for IGD->IGD conversion, but was not working for VCF->IGD conversion. Fixed and added a regression test.
* New `--drop-unphased` option which just drops all variants that contain any unphased data.