### PR TITLE
Add picovcf_parse_structured_meta() and fix minor VCF bugs

### DIFF
--- a/test/test_helpers.cpp
+++ b/test/test_helpers.cpp
@@ -160,3 +160,29 @@ TEST(Helper, IGDAllele) {
 
 }
 
+TEST(Helper, StructuredMetadata) {
+    std::map<std::string, std::string> result;
+    std::map<std::string, std::string> expected;
+    // Doesn't start/end with <...>
+    EXPECT_THROW(
+        result = picovcf_parse_structured_meta("no <> characters"),
+        MalformedFile);
+    // Unterminated quote
+    EXPECT_THROW(
+        result = picovcf_parse_structured_meta("<A=\"blah>"),
+        MalformedFile);
+
+    result = picovcf_parse_structured_meta("<>");
+    expected.clear();
+    EXPECT_EQ(result, expected);
+
+    result = picovcf_parse_structured_meta("<A=B,C=D>");
+    expected = {{"A", "B"}, {"C", "D"}};
+    EXPECT_EQ(result, expected);
+    result = picovcf_parse_structured_meta("<A=\"B\",C=\"D\">");
+    EXPECT_EQ(result, expected);
+
+    result = picovcf_parse_structured_meta("<A=\"this has = and , and > characters in a string\">");
+    expected = {{"A", "this has = and , and > characters in a string"}};
+    EXPECT_EQ(result, expected);
+}


### PR DESCRIPTION
picovcf_parse_structured_meta() helper function to parse structured meta-data lines (which are basically like a string-to-string map). With this, "INFO" fields can be fully parsed.

VCF parsing bugs:
* parseToVariantInfo() can be const
* Return quiet NaN when QUAL is "."
* getMetaInfo() is for a single metadata value, and throws an exception if more than one value is specified.
* getAllMetaInfo() is for 0 or more metadata values, and is the more general method. In particular this will capture all INFO fields now.
* Add a few std::move() calls for efficiency.