### PR TITLE
API improvements; deprecate some old APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(PICOVCF_TEST_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/test/test_igd.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/test_main.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/test_valid_vcf.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test/test_variant_view.cpp
   )
 
 if (${ENABLE_VCF_GZ})

--- a/doc/vcf_api.rst
+++ b/doc/vcf_api.rst
@@ -24,9 +24,6 @@ Classes and Methods for VCF Parsing
 .. doxygenclass:: picovcf::VCFVariantView
     :members:
 
-.. doxygenclass:: picovcf::IndividualIteratorGT
-    :members:
-
 .. doxygenfunction:: picovcf::picovcf_parse_structured_meta
 
 Structs

--- a/examples/vcfpp.cpp
+++ b/examples/vcfpp.cpp
@@ -39,9 +39,7 @@ int main(int argc, char* argv[]) {
         std::cout << "  Source: " << vcf.getMetaInfo("source") << std::endl;
         std::cout << "  Genome range: " << vcf.getGenomeRange().first << "-" << vcf.getGenomeRange().second
                   << std::endl;
-        vcf.seekBeforeVariants();
-        if (vcf.hasNextVariant()) {
-            vcf.nextVariant();
+        if (vcf.nextVariant()) {
             std::cout << "  Has genotype data? " << (vcf.currentVariant().hasGenotypeData() ? "yes" : "no")
                       << std::endl;
         }
@@ -50,22 +48,11 @@ int main(int argc, char* argv[]) {
         std::cout << "Columns: samples" << std::endl;
         // This assumes/checks for phased data.
         vcf.seekBeforeVariants();
-        while (vcf.hasNextVariant()) {
-            vcf.nextVariant();
-            VCFVariantView variant = vcf.currentVariant();
-            IndividualIteratorGT iterator = variant.getIndividualIterator();
-            while (iterator.hasNext()) {
-                VariantT allele1 = 0;
-                VariantT allele2 = 0;
-                bool isPhased = iterator.getAlleles(allele1, allele2);
-                if (!isPhased) {
-                    std::cerr << "Cannot create a matrix for unphased data" << std::endl;
-                    return 2;
-                }
-                emitAllele(allele1, std::cout);
-                if (allele2 != NOT_DIPLOID) {
-                    emitAllele(allele2, std::cout);
-                }
+        while (vcf.nextVariant()) {
+            VCFVariantView& variant = vcf.currentVariant();
+            std::vector<AlleleT> gt = variant.getGenotypeArray();
+            for (const auto allele : gt) {
+                emitAllele(allele, std::cout);
             }
             std::cout << std::endl;
         }

--- a/igdtools/igdtools.cpp
+++ b/igdtools/igdtools.cpp
@@ -97,7 +97,7 @@ inline std::string removeExt(const std::string& pathname) {
     return pathname;
 }
 
-void make_dir_or_throw(const std::string& directory) {
+void makeDirOrThrow(const std::string& directory) {
     std::stringstream ssErr;
     int rv = mkdir(directory.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (rv == 0) {
@@ -145,7 +145,7 @@ struct MetadataWriteInfo {
     MetadataWriteInfo(const std::string& prefix, const std::string& metadataFieldList)
         : metadataOutDirectory(prefix) {
 
-        make_dir_or_throw(metadataOutDirectory);
+        makeDirOrThrow(metadataOutDirectory);
 
         for (size_t i = 0; i < outputField.size(); i++) {
             outputField[i] = false;
@@ -170,7 +170,7 @@ struct MetadataWriteInfo {
 };
 
 // Write a variant-at-a-time metadata information.
-void writeNextVariant(const VCFFile& vcfFile, const VCFVariantView& variant, void* context) {
+void writeNextVariant(const VCFFile& vcfFile, VCFVariantView& variant, void* context) {
     PICOVCF_RELEASE_ASSERT(context != nullptr);
     MetadataWriteInfo* info = static_cast<MetadataWriteInfo*>(context);
 
@@ -282,9 +282,8 @@ void vcfExportMetadata(const std::string& vcfFilename,
     MetadataWriteInfo writeInfo(metadataOutDirectory, metadataFieldList);
 
     vcf.seekBeforeVariants();
-    while (vcf.hasNextVariant()) {
-        vcf.nextVariant();
-        const VCFVariantView& variant = vcf.currentVariant();
+    while (vcf.nextVariant()) {
+        VCFVariantView& variant = vcf.currentVariant();
         for (size_t i = 0; i < variant.getAltAlleles().size(); i++) {
             writeNextVariant(vcf, variant, &writeInfo);
         }
@@ -338,19 +337,11 @@ int main(int argc, char* argv[]) {
         "containing information about the metadata. This option takes a list of metadata to export, which "
         "can be: all, chrom, qual, filter, info",
         {'e', "--export-metadata"});
-    std::unordered_map<std::string, PloidyHandling> ploidyHandlingMap{
-        {"strict", PloidyHandling::PH_STRICT},
-        {"force-diploid", PloidyHandling::PH_FORCE_DIPLOID},
-    };
-    args::MapFlag<std::string, PloidyHandling> handlePloidy(
-        parser,
-        "handlePloidy",
-        "IGD files have a single ploidy, how should VCF files that violate this be handled? "
-        "Options:\n"
-        "  \"strict\": Fail if mixed ploidy is encountered\n"
-        "  \"force-diploid\": Force all samples to have diploid data, by mirroring haploid samples\n",
-        {'p', "handle-ploidy"},
-        ploidyHandlingMap);
+    args::ValueFlag<size_t> forceToPloidy(parser,
+                                          "forceToPloidy",
+                                          "IGD files have a single ploidy, but you can use this to force all "
+                                          "variants/individuals to have the same ploidy.",
+                                          {'p', "force-ploidy"});
     args::ValueFlag<std::string> updateIndividualIds(
         parser,
         "update-indiv-ids",
@@ -424,9 +415,8 @@ int main(int argc, char* argv[]) {
             UNSUPPORTED_FOR_VCF(keepSamples, "--samples");
 
             const bool emitVariantIds = !noVariantIds;
-            const PloidyHandling hploidy = handlePloidy ? *handlePloidy : PH_STRICT;
 
-            void (*variantCallback)(const VCFFile&, const VCFVariantView&, void*) = nullptr;
+            void (*variantCallback)(const VCFFile&, VCFVariantView&, void*) = nullptr;
             void* callbackContext = nullptr;
             std::unique_ptr<MetadataWriteInfo> writeInfo;
             if (exportMetadata) {
@@ -448,13 +438,13 @@ int main(int argc, char* argv[]) {
                      /*emitIndividualIds=*/true,
                      emitVariantIds,
                      forceUnphasedArg,
-                     hploidy,
+                     forceToPloidy ? *forceToPloidy : 0,
                      dropUnphased,
                      variantCallback,
                      callbackContext);
             return 0;
         } else {
-            ONLY_SUPPORTED_FOR_VCF(handlePloidy, "--handle-ploidy");
+            ONLY_SUPPORTED_FOR_VCF(forceToPloidy, "--force-ploidy");
             ONLY_SUPPORTED_FOR_VCF(dropUnphased, "--drop-unphased");
             ONLY_SUPPORTED_FOR_VCF(exportMetadata, "--export-metadata");
         }

--- a/test/test_igd.cpp
+++ b/test/test_igd.cpp
@@ -63,7 +63,7 @@ TEST(IGD, UnphasedData) {
 
 TEST(IGD, MixedPloidyData) {
     std::string igdFileName = "mixed_ploidy.igd";
-    vcfToIGD(getMIXED_DATA_EXAMPLE_FILE(), igdFileName, "", false, true, true, false, PH_FORCE_DIPLOID);
+    vcfToIGD(getMIXED_DATA_EXAMPLE_FILE(), igdFileName, "", false, true, true, false, 2);
 
     IGDData igdFile(igdFileName);
 

--- a/test/test_valid_vcf.cpp
+++ b/test/test_valid_vcf.cpp
@@ -26,21 +26,12 @@ TEST(ValidVCF, SpecExample) {
 
     vcf.seekBeforeVariants();
     for (size_t i = 0; i < EXPECT_VARIANTS; i++) {
-        ASSERT_TRUE(vcf.hasNextVariant());
-        vcf.nextVariant();
-        VCFVariantView variant = vcf.currentVariant();
-        IndividualIteratorGT iterator = variant.getIndividualIterator();
-        while (iterator.hasNext()) {
-            VariantT allele1 = 0;
-            VariantT allele2 = 0;
-            iterator.getAlleles(allele1, allele2);
-        }
+        ASSERT_TRUE(vcf.nextVariant());
     }
-    ASSERT_FALSE(vcf.hasNextVariant());
+    ASSERT_FALSE(vcf.nextVariant());
 
     vcf.seekBeforeVariants();
-    ASSERT_TRUE(vcf.hasNextVariant());
-    vcf.nextVariant();
+    ASSERT_TRUE(vcf.nextVariant());
     VCFVariantView& variant1 = vcf.currentVariant();
     ASSERT_EQ(variant1.getChrom(), "20");
     ASSERT_EQ(variant1.getPosition(), 14370);
@@ -48,44 +39,33 @@ TEST(ValidVCF, SpecExample) {
     ASSERT_EQ(variant1.getRefAllele(), "G");
     ASSERT_EQ(variant1.getAltAlleles(), std::vector<std::string>{"A"});
     ASSERT_TRUE(variant1.hasGenotypeData());
+    ASSERT_EQ(vcf.numIndividuals(), 3);
 
     // Check all individuals of the first variant
     VariantT allele1 = MISSING_VALUE;
     VariantT allele2 = MISSING_VALUE;
     bool isPhased;
-    IndividualIteratorGT iterator = variant1.getIndividualIterator();
-    // Do the first individual twice in a row.
-    ASSERT_TRUE(iterator.hasNext());
-    isPhased = iterator.getAlleles(allele1, allele2, /*moveNext=*/false);
-    ASSERT_TRUE(isPhased);
-    ASSERT_EQ(allele1, 0);
-    ASSERT_EQ(allele2, 0);
-    isPhased = iterator.getAlleles(allele1, allele2);
-    ASSERT_TRUE(isPhased);
-    ASSERT_EQ(allele1, 0);
-    ASSERT_EQ(allele2, 0);
-
-    ASSERT_TRUE(iterator.hasNext());
-    isPhased = iterator.getAlleles(allele1, allele2);
-    ASSERT_TRUE(isPhased);
-    ASSERT_EQ(allele1, 1);
-    ASSERT_EQ(allele2, 0);
-
-    ASSERT_TRUE(iterator.hasNext());
-    isPhased = iterator.getAlleles(allele1, allele2);
-    ASSERT_FALSE(isPhased);
-    ASSERT_EQ(allele1, 1);
-    ASSERT_EQ(allele2, 1);
-
-    ASSERT_FALSE(iterator.hasNext());
+    const auto& gtArray = variant1.getGenotypeArray();
+    const size_t ploidy = variant1.getMaxPloidy();
+    ASSERT_EQ(variant1.getPhasedness(), PVCFP_MIXED);
+    ASSERT_EQ(ploidy, 2);
+    // The first individual.
+    ASSERT_TRUE(variant1.getIsPhased().at(0));
+    ASSERT_EQ(gtArray.at(0), 0);
+    ASSERT_EQ(gtArray.at(1), 0);
+    // Second individual.
+    ASSERT_TRUE(variant1.getIsPhased().at(1));
+    ASSERT_EQ(gtArray.at(2), 1);
+    ASSERT_EQ(gtArray.at(3), 0);
+    // Third individual.
+    ASSERT_FALSE(variant1.getIsPhased().at(2));
+    ASSERT_EQ(gtArray.at(4), 1);
+    ASSERT_EQ(gtArray.at(5), 1);
 
     // Check a few things on the 4th variant
-    ASSERT_TRUE(vcf.hasNextVariant());
-    vcf.nextVariant();
-    ASSERT_TRUE(vcf.hasNextVariant());
-    vcf.nextVariant();
-    ASSERT_TRUE(vcf.hasNextVariant());
-    vcf.nextVariant();
+    ASSERT_TRUE(vcf.nextVariant());
+    ASSERT_TRUE(vcf.nextVariant());
+    ASSERT_TRUE(vcf.nextVariant());
     VCFVariantView& variant4 = vcf.currentVariant();
     ASSERT_EQ(variant4.getChrom(), "20");
     ASSERT_EQ(variant4.getPosition(), 1230237);
@@ -104,6 +84,7 @@ static bool hasSample(const IGDSampleList& samples, SampleT id) {
     return false;
 }
 
+// Equality between VCF and IGD on the same data.
 TEST(ValidVCF, Indexable) {
     constexpr size_t EXPECT_VARIANTS = 4;
     constexpr size_t EXPECT_INDIVIDUALS = 10000;
@@ -125,32 +106,23 @@ TEST(ValidVCF, Indexable) {
 
     size_t index = 0;
     vcf.seekBeforeVariants();
-    while (vcf.hasNextVariant()) {
-        vcf.nextVariant();
+    while (vcf.nextVariant()) {
         VCFVariantView& variant = vcf.currentVariant();
         ASSERT_FALSE(variant.getAltAlleles().size() > 1);
         bool isMissing = false;
         ASSERT_EQ(variant.getPosition(), indexableData.getPosition(index, isMissing));
         auto sampleSet = indexableData.getSamplesWithAlt(index);
-        IndividualIteratorGT individualIt = variant.getIndividualIterator();
-        SampleT sampleIndex = 0;
-        while (individualIt.hasNext()) {
-            VariantT allele1 = 255;
-            VariantT allele2 = 255;
-            individualIt.getAlleles(allele1, allele2);
-            if (allele1 == 1) {
-                if (!hasSample(sampleSet, sampleIndex)) {
-                    std::cout << "Variant " << index << " failed: ";
-                    std::cout << "missing sample " << sampleIndex << "\n";
-                }
-                ASSERT_TRUE(hasSample(sampleSet, sampleIndex));
-            }
-            sampleIndex++;
-            if (allele2 != NOT_DIPLOID) {
-                if (allele2 == 1) {
+        const auto& gtArray = variant.getGenotypeArray();
+        const size_t ploidy = variant.getMaxPloidy();
+        ASSERT_LE(ploidy, 2);
+        for (size_t indiv = 0; indiv < vcf.numIndividuals(); indiv++) {
+            ASSERT_TRUE(variant.getIsPhased().at(indiv));
+            const size_t baseIndex = indiv*ploidy;
+            for (size_t j = 0; j < ploidy; j++) {
+                const SampleT sampleIndex = baseIndex + j;
+                if (gtArray.at(sampleIndex) > 0 && gtArray.at(sampleIndex) < MISSING_VALUE) {
                     ASSERT_TRUE(hasSample(sampleSet, sampleIndex));
                 }
-                sampleIndex++;
             }
         }
         index++;
@@ -166,19 +138,17 @@ TEST(ValidVCF, Haploid) {
 
     vcf.seekBeforeVariants();
     for (size_t i = 0; i < EXPECT_VARIANTS; i++) {
-        ASSERT_TRUE(vcf.hasNextVariant());
-        vcf.nextVariant();
+        ASSERT_TRUE(vcf.nextVariant());
         VCFVariantView variant = vcf.currentVariant();
-        IndividualIteratorGT iterator = variant.getIndividualIterator();
-        while (iterator.hasNext()) {
-            VariantT allele1 = 0;
-            VariantT allele2 = 0;
-            const bool isPhased = iterator.getAlleles(allele1, allele2);
-            ASSERT_TRUE(isPhased);
-            ASSERT_EQ(allele2, NOT_DIPLOID);
+        const auto& gtArray = variant.getGenotypeArray();
+        const size_t ploidy = variant.getMaxPloidy();
+        ASSERT_EQ(ploidy, 1);
+        ASSERT_EQ(variant.getPhasedness(), PVCFP_PHASED);
+        for (size_t indiv = 0; indiv < vcf.numIndividuals(); indiv++) {
+            ASSERT_TRUE(variant.getIsPhased().at(indiv));
         }
     }
-    ASSERT_FALSE(vcf.hasNextVariant());
+    ASSERT_FALSE(vcf.nextVariant());
 }
 
 TEST(ValidVCF, MixedPloidy) {
@@ -190,21 +160,24 @@ TEST(ValidVCF, MixedPloidy) {
 
     vcf.seekBeforeVariants();
     for (size_t i = 0; i < EXPECT_VARIANTS; i++) {
-        ASSERT_TRUE(vcf.hasNextVariant());
-        vcf.nextVariant();
+        ASSERT_TRUE(vcf.nextVariant());
         VCFVariantView variant = vcf.currentVariant();
-        IndividualIteratorGT iterator = variant.getIndividualIterator();
-        while (iterator.hasNext()) {
-            VariantT allele1 = 0;
-            VariantT allele2 = 0;
-            const bool isPhased = iterator.getAlleles(allele1, allele2);
-            ASSERT_TRUE(isPhased);
-            // The first 2 variants are entirely haploid.
-            if (i < 2) {
-                ASSERT_EQ(allele2, NOT_DIPLOID);
+        const auto& gtArray = variant.getGenotypeArray();
+        const size_t ploidy = variant.getMaxPloidy();
+        ASSERT_EQ((double)gtArray.size() / (double)ploidy, (double)vcf.numIndividuals());
+        if (i < 2) {
+            ASSERT_EQ(ploidy, 1);
+        } else {
+            ASSERT_EQ(ploidy, 2);
+        }
+        for (size_t indiv = 0; indiv < vcf.numIndividuals(); indiv++) {
+            ASSERT_TRUE(variant.getIsPhased().at(indiv));
+            const size_t baseIndex = indiv*ploidy;
+            ASSERT_NE(gtArray.at(baseIndex), NOT_DIPLOID);
+            if (i >= 2) {
+                ASSERT_NE(gtArray.at(baseIndex+1), NOT_DIPLOID);
             }
         }
     }
-    ASSERT_FALSE(vcf.hasNextVariant());
+    ASSERT_FALSE(vcf.nextVariant());
 }
-

--- a/test/test_variant_view.cpp
+++ b/test/test_variant_view.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include "picovcf.hpp"
+
+#include <limits>
+#include <string>
+
+using namespace picovcf;
+
+TEST(VariantView, Split) {
+    std::string currentLine =
+        "22\t1001\tv123\tA\tG,T\t.\t.\t.\tGT\t"
+        "0|1\t1|1\t0|0\t1|0\t0|1";
+    VCFVariantView view(currentLine);
+    view.initialize(5);
+    view.reset();
+    ASSERT_EQ(view.getChrom(), "22");
+    ASSERT_EQ(view.getPosition(), 1001);
+    ASSERT_EQ(view.getID(), "v123");
+    ASSERT_EQ(view.getRefAllele(), "A");
+    std::vector<std::string> alts = {"G", "T"};
+    ASSERT_EQ(view.getAltAlleles(), alts);
+    ASSERT_TRUE(view.hasGenotypeData());
+    std::vector<AlleleT> gt = {0, 1, 1, 1, 0, 0, 1, 0, 0, 1};
+    ASSERT_EQ(view.getGenotypeArray(), gt);
+    ASSERT_EQ(view.getMaxPloidy(), 2);
+    ASSERT_EQ(view.getPhasedness(), PVCFP_PHASED);
+    for (size_t i = 0; i < view.getIsPhased().size(); i++) {
+        ASSERT_TRUE(view.getIsPhased()[i]);
+    }
+}
+
+TEST(VariantView, Mixtures) {
+    std::string currentLine =
+        "arbitrary\t29854309\tv123\tA\tG,TTTTTTTTTTT\t.\t.\t.\tGT\t"
+        "0/1\t1\t0|0|0\t1|0\t1|1";
+    VCFVariantView view(currentLine);
+    view.initialize(5);
+    view.reset();
+    ASSERT_EQ(view.getChrom(), "arbitrary");
+    ASSERT_EQ(view.getPosition(), 29854309);
+    ASSERT_EQ(view.getID(), "v123");
+    ASSERT_EQ(view.getRefAllele(), "A");
+    std::vector<std::string> alts = {"G", "TTTTTTTTTTT"};
+    ASSERT_EQ(view.getAltAlleles(), alts);
+    ASSERT_TRUE(view.hasGenotypeData());
+    std::vector<AlleleT> gt = {
+        0, 1, MIXED_PLOIDY,
+        1, MIXED_PLOIDY, MIXED_PLOIDY,
+        0, 0, 0,
+        1, 0, MIXED_PLOIDY,
+        1, 1, MIXED_PLOIDY,
+    };
+    ASSERT_EQ(view.getGenotypeArray(), gt);
+    ASSERT_EQ(view.getMaxPloidy(), 3);
+    ASSERT_EQ(view.getPhasedness(), PVCFP_MIXED);
+    ASSERT_FALSE(view.getIsPhased().at(0));
+    ASSERT_TRUE(view.getIsPhased().at(1));
+    ASSERT_TRUE(view.getIsPhased().at(2));
+    ASSERT_TRUE(view.getIsPhased().at(3));
+    ASSERT_TRUE(view.getIsPhased().at(4));
+}
+
+TEST(VariantView, LottaAlleles) {
+    std::string currentLine =
+        "22\t1001\tv123\tA\tG,T,C,GG,GT,GC,TT,TC,CC,GGG,GGT,GGC,GTT,GTC,GCC,TTT,TTG,TGG,TGC\t.\t.\t.\tGT\t"
+        "19|1\t10|1\t11|0\t13|.\t.|.";
+    VCFVariantView view(currentLine);
+    view.initialize(5);
+    view.reset();
+    ASSERT_EQ(view.getChrom(), "22");
+    ASSERT_EQ(view.getPosition(), 1001);
+    ASSERT_EQ(view.getID(), "v123");
+    ASSERT_EQ(view.getRefAllele(), "A");
+    std::vector<std::string> alts = {
+        "G", "T", "C", "GG", "GT", "GC", "TT", "TC", "CC", "GGG", "GGT", "GGC", "GTT",
+        "GTC", "GCC", "TTT", "TTG", "TGG", "TGC"};
+    ASSERT_EQ(view.getAltAlleles(), alts);
+    ASSERT_TRUE(view.hasGenotypeData());
+    std::vector<AlleleT> gt = {
+        19, 1, 10, 1, 11, 0, 13, MISSING_VALUE, MISSING_VALUE, MISSING_VALUE};
+    ASSERT_EQ(view.getGenotypeArray(), gt);
+    ASSERT_EQ(view.getMaxPloidy(), 2);
+    ASSERT_EQ(view.getPhasedness(), PVCFP_PHASED);
+    for (size_t i = 0; i < view.getIsPhased().size(); i++) {
+        ASSERT_TRUE(view.getIsPhased()[i]);
+    }
+}


### PR DESCRIPTION
1. getGenotypeArray() instead of GTIndividualIterator. Faster, and not limited to haploid/diploid samples. GTIndividualIterator is still around, but is marked deprecated and will be removed in a few releases.
2. forceToPloidy = X instead of the ploidy handling I had before, for vcf to IGD conversion. This is more general/useful.
3. Deprecate hasNextVariant() in favor of just returning a bool from nextVariant().

The new method getGenotypeArray() is simpler, but requires users to call other methods (getMaxPloidy(), getPhasedness(), getIsPhased()) to return the meta-data associated with the GT data.