### PR TITLE
Add IGD merging to C++ API

### DIFF
--- a/doc/igd_api.rst
+++ b/doc/igd_api.rst
@@ -17,3 +17,8 @@ VCF to IGD conversion
 
 .. doxygenfunction:: picovcf::vcfToIGD
 
+IGD merging
+~~~~~~~~~~~
+
+.. doxygenfunction:: picovcf::mergeIGDs
+


### PR DESCRIPTION
pyigd has had merging for a while. Merging IGD files is pretty fast, because it doesn't have to look at the genotype data it can just block copy them after sorting the files by position.